### PR TITLE
Fixed 'end of day' problem (fixes #10)

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,15 +85,15 @@ function getDateForText(text) {
     }
 
     if (text === "today") {
-        return moment().endOf("day");
+        return moment().tz("America/New_York").endOf("day");
     }
 
     if (text === "week") {
-        return moment().endOf("week");
+        return moment().tz("America/New_York").endOf("week");
     }
 
     if (text === "month") {
-        return moment().endOf("month");
+        return moment().tz("America/New_York").endOf("month");
     }
 }
 


### PR DESCRIPTION
This seems to have been another time zone issue.  Calculating the end of day for meetups starting at 7pm EST or later would technically be the next day GMT.  I added the timezone to those checks to make sure we get all the meetups for the current day.